### PR TITLE
Add support for testing RFC-0044 mime types

### DIFF
--- a/.github/workflows/test-harness-afgo.yml
+++ b/.github/workflows/test-harness-afgo.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           BUILD_AGENTS: "-a afgo-master"
           TEST_AGENTS: "-d afgo-master"
-          TEST_SCOPE: "-t @RFC0023,@T001.1-RFC0036,@RFC0453,@RFC0454 -t ~@wip -t ~@CredFormat_Indy"
+          TEST_SCOPE: "-t @RFC0023,@RFC0044,@T001.1-RFC0036,@RFC0453,@RFC0454 -t ~@wip -t ~@CredFormat_Indy"
           REPORT_PROJECT: afgo 
         continue-on-error: true
       - name: run-send-gen-test-results-secure

--- a/aries-backchannels/data/backchannel_operations.csv
+++ b/aries-backchannels/data/backchannel_operations.csv
@@ -1,6 +1,7 @@
 rfc,command,response,topic,method,operation,id,data,description,id_details,data_details,result_details
 0000 General Backchannel Commands,X,,status,GET,,,,"Return agent status, 200 if active or 418 otherwise",,,status
 0000 General Backchannel Commands,X,,version,GET,,,,"Return agent version, 200 if exists or 404 otherwise",,,version
+0000 General Backchannel Commands,X,,agent,POST,start,,Y,,,parameters,
 0160 Connection Protocol,X,,connection,POST,create-invitation,,Y,Create a new invitation ,,invitation,"connection_id, state"
 0160 Connection Protocol,X,,connection,POST,receive-invitation,,Y,Receive an invitation,,invitation,"connection_id, state"
 0160 Connection Protocol,X,,connection,POST,accept-invitation,Y,Y,Accept an invitation,connection_id,request,"connection_id, state"

--- a/aries-test-harness/features/0044-mime-types.feature
+++ b/aries-test-harness/features/0044-mime-types.feature
@@ -1,0 +1,41 @@
+@RFC0044 @AIP20
+Feature: RFC0044 didcomm mime types
+
+   @T001-RFC0044
+   Scenario: Perform DID Exchange between two agents that have the same default envelope MIME type
+      Given we have "2" agents
+         | name | role      |
+         | Acme | requester |
+         | Bob  | responder |
+      And "Acme" is running with parameters "{"mime-type":"didcomm/aip2;env=rfc19"}"
+      And "Bob" is running with parameters "{"mime-type":"didcomm/aip2;env=rfc19"}"
+      When "Bob" sends an explicit invitation
+      And "Acme" receives the invitation
+      And "Acme" sends the request to "Bob"
+      And "Bob" receives the request
+      And "Bob" sends a response to "Acme"
+      And "Acme" receives the response
+      And "Acme" sends complete to "Bob"
+      Then "Acme" and "Bob" have a connection
+
+   @T002-RFC0044
+   Scenario Outline: Perform DID Exchange between two permissive agents that have different default envelope MIME types
+      Given we have "2" agents
+         | name | role      |
+         | Acme | requester |
+         | Bob  | responder |
+      And "Acme" is running with parameters "{"mime-type":<acme-mime-type>}"
+      And "Bob" is running with parameters "{"mime-type":<bob-mime-type>}"
+      When "Bob" sends an explicit invitation
+      And "Acme" receives the invitation
+      And "Acme" sends the request to "Bob"
+      And "Bob" receives the request
+      And "Bob" sends a response to "Acme"
+      And "Acme" receives the response
+      And "Acme" sends complete to "Bob"
+      Then "Acme" and "Bob" have a connection
+
+      Examples:
+         | acme-mime-type | bob-mime-type |
+         | "didcomm/aip1" | "didcomm/v2"  |
+         | "didcomm/v2"   | "didcomm/aip1"|

--- a/aries-test-harness/features/Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv
+++ b/aries-test-harness/features/Mapping Aries Protocols for Testing - Aries Agent Test Scripts.csv
@@ -1,6 +1,7 @@
 RFC,Role,Step #,Steps,State,Method,Command,Response,Topic,Operation,Id,Data Parameter,Result,Description,Notes
 0000 General Backchallel Commands,,,,,,,,,,,,,,
 ,Controller,0,Get agent/backchannel status,,GET,X,,status,,,,status,"Return agent status, 200 if active or 418 otherwise",Status returned as http status; response text is ignored
+,Controller,2,Start/restart agent with parameters,,POST,X,,agent,start,,parameters,,,
 ,,,,,,,,,,,,,,
 0160 Connection Protocol,,,,,,,,,,,,,,
 ,,0,No existing connection between Inviter and Invitee,,,,,,,,,,,

--- a/aries-test-harness/features/steps/0023-did-exchange.py
+++ b/aries-test-harness/features/steps/0023-did-exchange.py
@@ -179,8 +179,8 @@ def step_impl(context, responder):
 
 @when('"{requester}" receives the invitation')
 def step_impl(context, requester):
-    # if feature is DID Exchange then set use existing connection to false
-    if "0023" in context.feature.name:
+    # if feature is DID Exchange or MIME Types then set use existing connection to false
+    if "0023" in context.feature.name or "0044" in context.feature.name:
         context.use_existing_connection = False
     data = context.responder_invitation
     data["use_existing_connection"] = context.use_existing_connection

--- a/aries-test-harness/features/steps/0044-mime-types.py
+++ b/aries-test-harness/features/steps/0044-mime-types.py
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------
+# Behave Step Definitions for Aries DIDComm File and MIME Types, RFC 0044:
+# https://github.com/hyperledger/aries-rfcs/blob/main/features/0044-didcomm-file-and-mime-types/README.md
+#
+# -----------------------------------------------------------
+
+from time import sleep
+from behave import given, when, then
+import json, time
+from agent_backchannel_client import agent_backchannel_GET, agent_backchannel_POST, expected_agent_state, setup_already_connected
+
+@given('"{agent}" is running with parameters "{parameters}"')
+def step_impl(context, agent, parameters):
+    print(f"PARAMETERS: {parameters}")
+    agent_url = context.config.userdata.get(agent)
+
+    params_json = json.loads(parameters)
+
+    data = {
+        "parameters": params_json
+    }
+
+    (resp_status, resp_text) = agent_backchannel_POST(agent_url + "/agent/command/", "agent", operation="start", data=data)
+    assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
+
+    # raise NotImplementedError(f'STEP: Given "{agent}" is running with parameters "{parameters}"')

--- a/docs/assets/openapi-spec.yml
+++ b/docs/assets/openapi-spec.yml
@@ -83,7 +83,7 @@ paths:
   /agent/command/version:
     get:
       summary: Get agent/backchannel version
-      operationId: StatusGet
+      operationId: VersionGet
       tags:
         - Status
       responses:
@@ -95,6 +95,32 @@ paths:
                 type: string
                 example: 0.6.0
 
+  /agent/command/agent/start:
+    post:
+      summary: (re)start the agent
+      operationId: AgentStart
+      tags:
+        - Status
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - parameters
+              properties:
+                parameters:
+                  type: object
+                  example:
+                    {
+                      "mime-type": "didcomm/v2"
+                    }
+      responses:
+        200:
+          description: OK
+        500:
+          description: Failed
   /agent/command/connection:
     get:
       tags:


### PR DESCRIPTION
- Adds `/agent/start` backchannel POST command, which tells the backchannel to (re)start its agent, and includes a set of parameters to include in the agent's configuration (whether as command-line parameters, environment variables, or otherwise). Parameters have generic names on the AATH side, and must be translated by the backchannel for the given agent implementation. In this PR only one parameter is introduced, `mime-type` to specify the default mime type for the agent's outgoing messages as per Aries RFC 0044.
- Adds support for `/agent/start` to afgo backchannel, handling the `mime-type` parameter.
- Adds a new step that (re)starts a given agent with a given set of extra parameters.
- Adds a BDD feature for RFC 0044, that restarts Acme and Bob with given default mime types, and performs didexchange to demonstrate permissive agent acceptance of incoming mime types.