### PR TITLE
cloud agency only runs for vcx

### DIFF
--- a/manage
+++ b/manage
@@ -710,11 +710,14 @@ startHarness(){
 
   startServices auto
 
-  startCloudAgency
+  # Only start cloud agency if vcx is in the agent list to run.
+  if [[ "${ACME}" = "aries-vcx" ]] || [[ "${BOB}" = "aries-vcx" ]] || [[ "${MALLORY}" = "aries-vcx" ]] || [[ "${FABER}" = "aries-vcx" ]]; then
+    startCloudAgency
 
-  if ! waitForCloudAgency; then
-    echoRed "\nThe cloud agency not running.\n"
-    exit 1
+    if ! waitForCloudAgency; then
+      echoRed "\nThe cloud agency not running.\n"
+      exit 1
+    fi
   fi
 
   dockerhost_url_templates
@@ -740,7 +743,10 @@ startHarness(){
 
   echo
   # Allure Reports environment.properties file handling
-  writeEnvProperties
+  # Only do this if reporting parameter is passed. 
+  if [[ "${REPORT}" = "allure" ]]; then
+    writeEnvProperties
+  fi
 }
 
 deleteAgents() {


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Removes the running of the cloud agency for all agents. It will now only run for a vcx agent.

Also removed the creation of the environment.properties files unless `-r allure` us used for reporting. 