### PR TITLE
chore: update afj, remove setTimeouts

### DIFF
--- a/aries-backchannels/javascript/Dockerfile.javascript
+++ b/aries-backchannels/javascript/Dockerfile.javascript
@@ -46,7 +46,8 @@ RUN yarn install
 
 # Copy other depedencies
 COPY javascript/server .
+COPY javascript/ngrok-wait.sh ./ngrok-wait.sh
 
 # For now we use ts-node. Compiling with typescript
 # doesn't work because indy-sdk types are not exported
-ENTRYPOINT [ "yarn", "ts-node", "src/index.ts" ]
+ENTRYPOINT [ "bash", "ngrok-wait.sh"]

--- a/aries-backchannels/javascript/ngrok-wait.sh
+++ b/aries-backchannels/javascript/ngrok-wait.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# based on code developed by Sovrin:  https://github.com/hyperledger/aries-acapy-plugin-toolbox
+
+if [[ ! "${NGROK_NAME}" = "" ]]; then
+    echo "using ngrok end point [$NGROK_NAME]"
+
+    NGROK_ENDPOINT=null
+    while [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]
+    do
+        echo "Fetching end point from ngrok service"
+        NGROK_ENDPOINT=$(curl -s $NGROK_NAME:4040/api/tunnels/command_line | grep -o "https:\/\/.*\.ngrok\.io")
+
+        if [ -z "$NGROK_ENDPOINT" ] || [ "$NGROK_ENDPOINT" = "null" ]; then
+            echo "ngrok not ready, sleeping 5 seconds...."
+            sleep 5
+        fi
+    done
+
+    export AGENT_PUBLIC_ENDPOINT=$NGROK_ENDPOINT
+    echo "fetched end point [$AGENT_PUBLIC_ENDPOINT]"
+fi
+
+echo "Starting AFJ agent ..."
+
+yarn ts-node src/index.ts "$@"

--- a/aries-backchannels/javascript/server/package.json
+++ b/aries-backchannels/javascript/server/package.json
@@ -10,27 +10,27 @@
     "start:prod": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
-    "@aries-framework/core": "^0.1.0-alpha.233",
-    "@aries-framework/node": "^0.1.0-alpha.233",
-    "@tsed/common": "6.25.2",
-    "@tsed/core": "6.25.2",
-    "@tsed/di": "6.25.2",
-    "@tsed/exceptions": "6.25.2",
-    "@tsed/platform-express": "6.25.2",
+    "@aries-framework/core": "latest",
+    "@aries-framework/node": "latest",
+    "@tsed/common": "6.75.4",
+    "@tsed/core": "6.75.4",
+    "@tsed/di": "6.75.4",
+    "@tsed/exceptions": "6.75.4",
+    "@tsed/platform-express": "6.75.4",
     "body-parser": "1.19.0",
     "cross-env": "7.0.3",
     "express": "^4.17.1",
     "minimist": "^1.2.5",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.5",
+    "rxjs": "^7.4.0"
   },
   "devDependencies": {
-    "@types/express": "4.17.11",
-    "@types/indy-sdk": "^1.16.5",
+    "@types/express": "4.17.13",
+    "@types/indy-sdk": "^1.16.7",
     "@types/minimist": "^1.2.0",
     "@types/node": "14.14.28",
-    "@types/node-fetch": "^2.5.7",
-    "nodemon": "2.0.7",
-    "ts-node": "9.1.1",
-    "typescript": "4.0.2"
+    "nodemon": "2.0.14",
+    "ts-node": "10.3.0",
+    "typescript": "~4.3.0"
   }
 }

--- a/aries-backchannels/javascript/server/src/TsedLogger.ts
+++ b/aries-backchannels/javascript/server/src/TsedLogger.ts
@@ -17,7 +17,7 @@ export class TsedLogger extends BaseLogger {
   } as const;
 
   public constructor(logger: Logger) {
-    super(LogLevel.test);
+    super(LogLevel.debug);
     this.logger = logger;
   }
 

--- a/aries-backchannels/javascript/server/src/controllers/CredentialDefinitionController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/CredentialDefinitionController.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, PathParams, Post, BodyParams } from "@tsed/common";
 import { InternalServerError, NotFound } from "@tsed/exceptions";
-import { Agent } from "@aries-framework/core";
+import { Agent, IndyAgentService } from "@aries-framework/core";
+import type * as Indy from "indy-sdk";
 
 @Controller("/agent/command/credential-definition")
 export class CredentialDefinitionController {
@@ -13,7 +14,7 @@ export class CredentialDefinitionController {
   @Get("/:credentialDefinitionId")
   async getCredentialDefinitionById(
     @PathParams("credentialDefinitionId") credentialDefinitionId: string
-  ) {
+  ): Promise<Indy.CredDef> {
     try {
       const credentialDefinition =
         await this.agent.ledger.getCredentialDefinition(credentialDefinitionId);
@@ -43,7 +44,10 @@ export class CredentialDefinitionController {
       support_revocation: boolean;
       schema_id: string;
     }
-  ) {
+  ): Promise<{
+    credential_definition_id: string;
+    credential_definition: Indy.CredDef;
+  }> {
     // TODO: handle schema not found exception
     try {
       const schema = await this.agent.ledger.getSchema(data.schema_id);
@@ -51,7 +55,6 @@ export class CredentialDefinitionController {
       const credentialDefinition =
         await this.agent.ledger.registerCredentialDefinition({
           schema,
-          signatureType: "CL",
           supportRevocation: data.support_revocation,
           tag: data.tag,
         });
@@ -61,7 +64,10 @@ export class CredentialDefinitionController {
         credential_definition: credentialDefinition,
       };
     } catch (error) {
-      throw new InternalServerError(`Error registering credential definition: ${error.message}`, error)
+      throw new InternalServerError(
+        `Error registering credential definition: ${error.message}`,
+        error
+      );
     }
   }
 }

--- a/aries-backchannels/javascript/server/src/controllers/SchemaController.ts
+++ b/aries-backchannels/javascript/server/src/controllers/SchemaController.ts
@@ -15,7 +15,9 @@ export class SchemaController {
   }
 
   @Get("/:schemaId")
-  async getSchemaById(@PathParams("schemaId") schemaId: string) {
+  async getSchemaById(
+    @PathParams("schemaId") schemaId: string
+  ): Promise<Schema> {
     try {
       const schema = await this.agent.ledger.getSchema(schemaId);
 

--- a/aries-backchannels/javascript/server/src/index.ts
+++ b/aries-backchannels/javascript/server/src/index.ts
@@ -27,9 +27,14 @@ async function bootstrap() {
   const dockerHost = process.env.DOCKERHOST ?? "host.docker.internal";
   const runMode = process.env.RUN_MODE;
   const externalHost = runMode === "docker" ? dockerHost : "localhost";
-  const agentName =  process.env.AGENT_NAME ? `AFJ ${process.env.AGENT_NAME}` : `AFJ Agent (${agentPort})`;
+  const agentName = process.env.AGENT_NAME
+    ? `AFJ ${process.env.AGENT_NAME}`
+    : `AFJ Agent (${agentPort})`;
 
-  const endpointUrl = `http://${externalHost}`;
+  let endpointUrl = process.env.AGENT_PUBLIC_ENDPOINT;
+  if (!endpointUrl) {
+    endpointUrl = `http://${externalHost}:${agentPort}`;
+  }
 
   // There are multiple ways to retrieve the genesis file
   // we account for all of them
@@ -50,9 +55,10 @@ async function bootstrap() {
   const agent = await createAgent({
     agentName,
     port: agentPort,
-    endpoint: `${endpointUrl}:${agentPort}`,
+    endpoint: endpointUrl,
     publicDidSeed,
     genesisPath,
+    useLegacyDidSovPrefix: true,
   });
 
   registerProvider({

--- a/aries-backchannels/javascript/server/src/utils/CredentialUtils.ts
+++ b/aries-backchannels/javascript/server/src/utils/CredentialUtils.ts
@@ -1,4 +1,5 @@
 import { Agent, CredentialRepository } from "@aries-framework/core";
+import type * as Indy from "indy-sdk";
 import { IndyHolderService } from "@aries-framework/core/build/modules/indy/services/IndyHolderService";
 
 export class CredentialUtils {
@@ -18,7 +19,9 @@ export class CredentialUtils {
     return this.credentialRepository.getSingleByQuery({ threadId });
   }
 
-  public async getIndyCredentialById(credentialId: string) {
+  public async getIndyCredentialById(
+    credentialId: string
+  ): Promise<Indy.IndyCredentialInfo> {
     const indyCredential = await this.holderService.getCredential(credentialId);
 
     return indyCredential;

--- a/aries-backchannels/javascript/server/yarn.lock
+++ b/aries-backchannels/javascript/server/yarn.lock
@@ -2,12 +2,15 @@
 # yarn lockfile v1
 
 
-"@aries-framework/core@0.1.0-alpha.233+cdf2edd", "@aries-framework/core@^0.1.0-alpha.233":
-  version "0.1.0-alpha.233"
-  resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.1.0-alpha.233.tgz#5cb3bc5187c03218606253c986c7b2286d30927d"
-  integrity sha512-JfXoSurnPS6iLcqJdXWYtXcv4P3KshZ+wK2/kAXWzV+A3jy5M1xAKcoH/F0lMCeY88T/EzrEizo/suqjJdRCaA==
+"@aries-framework/core@0.1.0-alpha.287+47149bc", "@aries-framework/core@latest":
+  version "0.1.0-alpha.287"
+  resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.1.0-alpha.287.tgz#e1465670a63e74963819ad787d93a2c65e97a6a2"
+  integrity sha512-tHJd2ViKH3dECQ8jUy0w9Dl6V07rbs6LA5TA0hev0rlI6Pidus4s0ZJZC8lnMrSiF13ckaIU0EdDKEMcOSFuLw==
   dependencies:
-    "@types/indy-sdk" "^1.16.5"
+    "@multiformats/base-x" "^4.0.1"
+    "@types/indy-sdk" "^1.16.6"
+    "@types/node-fetch" "^2.5.10"
+    "@types/ws" "^7.4.4"
     abort-controller "^3.0.0"
     bn.js "^5.2.0"
     borc "^3.0.0"
@@ -15,25 +18,40 @@
     class-transformer "^0.4.0"
     class-validator "^0.13.1"
     js-sha256 "^0.9.0"
+    lru_map "^0.4.1"
+    luxon "^1.27.0"
     make-error "^1.3.6"
     multibase "^4.0.4"
     multihashes "^4.0.2"
     object-inspect "^1.10.3"
+    query-string "^7.0.1"
     reflect-metadata "^0.1.13"
     rxjs "^7.1.0"
     tsyringe "^4.5.0"
     uuid "^8.3.2"
 
-"@aries-framework/node@^0.1.0-alpha.233":
-  version "0.1.0-alpha.233"
-  resolved "https://registry.yarnpkg.com/@aries-framework/node/-/node-0.1.0-alpha.233.tgz#f25660ef599e29b2e16fd655ba04f5a77814bf69"
-  integrity sha512-O6wNZ2dXZeF+/2Kb8Kho00pY62LXh+HF4ItaeF3qXWQMchvT0RLl3V8YF89+QFvoFpyi1hjUESlRMzgIo9fMUg==
+"@aries-framework/node@latest":
+  version "0.1.0-alpha.287"
+  resolved "https://registry.yarnpkg.com/@aries-framework/node/-/node-0.1.0-alpha.287.tgz#aff27b344bbaceef50a11d245ec73eca89e8b555"
+  integrity sha512-jQKeHToYUzOuJLj1ZHx6arK3xuDe8jM9zJwI82zl0vYIjEuZ+Zo8smC0CC9HAf3oEj5QmYHywDueiWjPDtuRFw==
   dependencies:
-    "@aries-framework/core" "0.1.0-alpha.233+cdf2edd"
+    "@aries-framework/core" "0.1.0-alpha.287+47149bc"
     express "^4.17.1"
-    indy-sdk "^1.16.0-dev-1634"
+    indy-sdk "^1.16.0-dev-1636"
     node-fetch "^2.6.1"
     ws "^7.5.3"
+
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
 
 "@multiformats/base-x@^4.0.1":
   version "4.0.1"
@@ -91,96 +109,194 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tsed/common@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/common/-/common-6.25.2.tgz#c7aa723bfb53818c885efaafeea01ce0891c8c3d"
-  integrity sha512-DCeG0sh5sMfrDZeqe+wZM+K1PPllMcfccoTMUXJtZ5WaPyQNSpGhzCrsaZERI7IRNuLAmXHDsTFL0/PUTIe4DA==
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
+"@tsed/common@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/common/-/common-6.75.4.tgz#5c2f89a6e8f74aec131754de78e194f8d1cbd5a9"
+  integrity sha512-E1lPbP2pgZeQYORKd9JSINkmMOI0XwnBr9keuUN8ZFixBFUQudH1QTbxBMg75zLGzXqBsgUBpsW2M3bUIaoUnQ==
   dependencies:
-    "@tsed/core" "6.25.2"
-    "@tsed/di" "6.25.2"
-    "@tsed/exceptions" "6.25.2"
-    "@tsed/json-mapper" "6.25.2"
-    "@tsed/logger" "^5.5.4"
-    "@tsed/schema" "6.25.2"
-    "@types/json-schema" "7.0.6"
-    consolidate "^0.16.0"
-    ejs "^3.1.5"
-    globby "11.0.1"
+    "@tsed/components-scan" "6.75.4"
+    "@tsed/core" "6.75.4"
+    "@tsed/di" "6.75.4"
+    "@tsed/exceptions" "6.75.4"
+    "@tsed/json-mapper" "6.75.4"
+    "@tsed/logger" "^5.16.0"
+    "@tsed/perf" "6.75.4"
+    "@tsed/platform-cache" "6.75.4"
+    "@tsed/platform-exceptions" "6.75.4"
+    "@tsed/platform-log-middleware" "6.75.4"
+    "@tsed/platform-middlewares" "6.75.4"
+    "@tsed/platform-params" "6.75.4"
+    "@tsed/platform-response-filter" "6.75.4"
+    "@tsed/platform-views" "6.75.4"
+    "@tsed/schema" "6.75.4"
+    "@types/json-schema" "7.0.7"
     json-schema "^0.2.3"
     on-finished "2.3.0"
-    tslib "2.0.1"
+    tslib "2.2.0"
     uuid "8.3.2"
 
-"@tsed/core@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/core/-/core-6.25.2.tgz#1d4b2c5e9b67ffbb5a414f8ef7fb7b4d534159dc"
-  integrity sha512-FiN53SWvbdHMY7O1HNgiOpPQBtuW5TtFLCHQDBToczy5aBrwMrcEyIkN5xxRzWDmi8wE4uXpT1tvTVwS6Ou5Ag==
+"@tsed/components-scan@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/components-scan/-/components-scan-6.75.4.tgz#d44d0bb113a52080c44b1af1bee23602cbebdb12"
+  integrity sha512-GqqZEi9rNXQeUxb6LLxYaBb6PMns7BUSGQUtD9xveCq/ic2PP8YMfuKM5pfgNOgGTKH5ewQkiYUkQ+/hM8Xk0Q==
   dependencies:
+    "@tsed/core" "6.75.4"
+    "@tsed/di" "6.75.4"
+    globby "11.0.3"
     normalize-path "3.0.0"
+    tslib "2.2.0"
+
+"@tsed/core@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/core/-/core-6.75.4.tgz#06e5c44c64f3650eb22637b66f52e3e2ab19d4b2"
+  integrity sha512-Y/5psk7ij/C36xXAJjnbjxc1xiP90YNQMQmqD1ju4sXrbAzvmGTELuV++ikluv6Hk6TSSizB9AUzKRCaYV604A==
+  dependencies:
     reflect-metadata "^0.1.13"
-    source-map-support "0.5.19"
-    tslib "2.0.1"
+    tslib "2.2.0"
 
-"@tsed/di@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/di/-/di-6.25.2.tgz#e92b5d5743a8fd4f83be56f09b2d384ea9685f9d"
-  integrity sha512-tJVCH6qUp7zqwZgCQ3QsOoc+qeQiYWjhmXIUrZcFx0bpmAN2GAxwi3W2+1R9+g0L/cRDg0xvcItjQ8FZ1Jlj+w==
+"@tsed/di@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/di/-/di-6.75.4.tgz#a655e75d9b7adccfe9fd964d2d54f4d114e4e801"
+  integrity sha512-hkOp7xhZ5yMTgrPKV9nRjgwAjDvU1V77Gg3EwypStvTvpdXa4O5loe7048SATeCKSN1fUe6ddqtv6KX7G7amYw==
   dependencies:
-    "@tsed/core" "6.25.2"
+    "@tsed/core" "6.75.4"
     chalk "4.1.0"
-    tslib "2.0.1"
+    tslib "2.2.0"
 
-"@tsed/exceptions@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/exceptions/-/exceptions-6.25.2.tgz#fae6960738572adca339d71aef18787b06467cdf"
-  integrity sha512-kg3wNSAcbBi6F+AXQh+qdFzCoED7egi6Eju47ukFJRU6A2QFkL7sfui5fbfZ+PAiY8tbFPgdWvQfYbUsPJ2TTw==
+"@tsed/exceptions@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/exceptions/-/exceptions-6.75.4.tgz#190cf08cf7cff1da40e2ebc5f59085c1b5da1faf"
+  integrity sha512-GoP0ywoEB78PihOIzjZz0DmhPbICmtllxSfqeUqKMFAe0vIYZOfdwd4rK4C16z+1KOnF/YwTY8FbnV2vfmHIRw==
   dependencies:
-    "@tsed/schema" "6.25.2"
-    tslib "2.0.1"
+    "@tsed/schema" "6.75.4"
+    tslib "2.2.0"
 
-"@tsed/json-mapper@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/json-mapper/-/json-mapper-6.25.2.tgz#42186d1ea7187fdddb4cd32a76878fad5e502f98"
-  integrity sha512-qMmKsSFvWEYKg3PQM/ujFXLphFwREz0begJauCf9VrSdrKoUtKn/glVsIsTxW8m+1ql3DIocUb7C3OmvRMH45g==
+"@tsed/json-mapper@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/json-mapper/-/json-mapper-6.75.4.tgz#6e3878fb9aee545a8908d7407997d3f89bc98765"
+  integrity sha512-BgtM8GVCbIzIAzqECndYwMasuqFGVJ6+tuFcQt9WyIMRyNxbUT1y3ue/rrch0F0AbLmZLGPJhjU4V/JVVmBHXQ==
   dependencies:
-    "@tsed/core" "6.25.2"
-    tslib "2.0.1"
+    tslib "2.2.0"
 
-"@tsed/logger@^5.5.4":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-5.15.0.tgz#ae9506d684adad1b05c2b00db4708cf96dc4cca5"
-  integrity sha512-3LaPh41/FheKzOfjGK5wq/wlLLz2Pz3Dy4rTzRDWsJLYX4M6bm+v5TFMmh9qgwrlk4xxiSTGzS3U2j4iSNzxpA==
+"@tsed/logger@^5.16.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-5.17.0.tgz#ec99e161112eca39c11f825a95fd892d76071822"
+  integrity sha512-co8DdRgtQaisudEQFP2/7y/ji9bnB9QrJYfEr0SEqdHIBJdwuq8joo2vyfOY8ht/w5LOcqo2NVebtwULSsD9Pg==
   dependencies:
     colors "^1.3.3"
     date-format "^3.0.0"
     lodash "^4.17.21"
     semver "^7.3.2"
     streamroller "^1.0.3"
-    tslib "2.1.0"
+    tslib "2.3.0"
 
-"@tsed/openspec@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/openspec/-/openspec-6.25.2.tgz#cbf4f2443bee0aaa6135263839cdf3a13e7a2054"
-  integrity sha512-yLQie/IMFwaYLEfGf1B45naQbubbQAWJ1cKzW464ezgiWLGIvThBr8Y7hg4hCiAkhxsxxcSEtTctC8EhtbEdPw==
+"@tsed/openspec@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/openspec/-/openspec-6.75.4.tgz#461bfc2fbf23ad692333cc1fe26ecfb4d6644482"
+  integrity sha512-2svYuGvDYXg90VUOwgqWvIfuI/sjR3Sbfs4DDgfESezOoFcgCzgMjDeyIP0GFInNIRslOL7g8Ehx+0G0dz5ipA==
 
-"@tsed/platform-express@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/platform-express/-/platform-express-6.25.2.tgz#05fdc6eeeab385fb247d291153b58624270b68cb"
-  integrity sha512-vA3+P8mrMgj1gI8m55ztq+Q2XbFBiwUayQWMiuBk2NN3vVAEgWhtpVS77skcJIfXGTOYFzLkZOUxpw+2C+5zTA==
+"@tsed/perf@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/perf/-/perf-6.75.4.tgz#569dfa7126f458d2428675907ba32f2d489be7b7"
+  integrity sha512-P/SWmvqwJkD1sAAEEniET61x2DQ8fwmC5WPnFB8srRTOmOFl/zi0mjxo61Wu06/hmoDFiTKiya2qSYNHWu7n2A==
+  dependencies:
+    "@tsed/core" "6.75.4"
+    chalk "^4.1.0"
+    tslib "2.2.0"
+
+"@tsed/platform-cache@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-cache/-/platform-cache-6.75.4.tgz#b6da93232da3f3f2335bce8d6e2b27604ad67863"
+  integrity sha512-lI+/5pdtaJNKoZ/71mMNZBVIEW4Zu7ABPgSzSaBGWIK6+8XiBINqPFBScNQDYNqgF7tz9DGqM0QzS6NTyG6CYQ==
+  dependencies:
+    "@types/cache-manager" "^3.4.2"
+    cache-manager "^3.4.1"
+    micromatch "^4.0.2"
+    tslib "2.2.0"
+
+"@tsed/platform-exceptions@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-exceptions/-/platform-exceptions-6.75.4.tgz#c4c56f28a48c8f7634e4901c399cab26b9381767"
+  integrity sha512-xo0J1CESvojxLfIjCzcUt3j9uvwApl38LmTltkgZVOr9RDp6KuvAc8VNzYPmz6UFth5rjHTJPrQm8jB5smv90w==
+  dependencies:
+    tslib "2.2.0"
+
+"@tsed/platform-express@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-express/-/platform-express-6.75.4.tgz#121f3df017ed5bfa5f41b7208b2d46748a6777a5"
+  integrity sha512-9NksoKirGSYuYoqthMfXSUZm+wpfHPZ2bSt+i00LyPkeL3pqRHQOihg7Zfvmv9ORR5O5d0EJQTQzNp5mdsLlGQ==
   dependencies:
     express "^4.17.1"
     multer "^1.4.2"
+    tslib "2.2.0"
 
-"@tsed/schema@6.25.2":
-  version "6.25.2"
-  resolved "https://registry.yarnpkg.com/@tsed/schema/-/schema-6.25.2.tgz#3876dd7cdbbcb0d20fc29d5647825bc36b626b0b"
-  integrity sha512-EKfuw+/V4D90URfAr6uRN0SqwXhykg9fMBRIcKfQu+NjNdPF2sEjU3WD7PJQjy+AaOzs1MvvlJZLNJg/IkXt7Q==
+"@tsed/platform-log-middleware@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-log-middleware/-/platform-log-middleware-6.75.4.tgz#49e33ac4167af0aa500b6f8ecdd68b71ea420a85"
+  integrity sha512-ZZKZJEhzxrd9gElv6adBQE61DoI49ekh2bOw0y7HzjHbMzDsRSsFQhNLUBpWI884Wp8dlrr5+m/1sPVrBLZOvg==
   dependencies:
-    "@tsed/core" "6.25.2"
-    "@tsed/openspec" "6.25.2"
-    change-case "4.1.1"
+    tslib "2.2.0"
+
+"@tsed/platform-middlewares@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-middlewares/-/platform-middlewares-6.75.4.tgz#92469f57dc80bc4953effcf7b2d9bc03fb728390"
+  integrity sha512-OiInpQjYNc+qSgADdSCUrByoY5X/8CSYcodnzf7iMgS1wCJ9itk6yiUuXG7gJmNk0mGwJcq9Gvas+W4Ctz7SWQ==
+  dependencies:
+    tslib "2.2.0"
+
+"@tsed/platform-params@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-params/-/platform-params-6.75.4.tgz#a66f1caa41b58fd46cc745fadf962b87c8d4c520"
+  integrity sha512-w6vZ94QRZRaTIKiI4/sNVAA8MGjOJDj6nlKaKaiKf6PWgkCtHJGWYEvzPD0+Koi45B03vLYRCL9uFcTwk8ObWA==
+  dependencies:
+    tslib "2.2.0"
+
+"@tsed/platform-response-filter@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-response-filter/-/platform-response-filter-6.75.4.tgz#4402c38598182f49cbf6f2ec800c648fb17700e1"
+  integrity sha512-sweRBBmL+FGkr6t71ArJE3jwpjTZ07WLCNMxB4SQt8CE2rPc/NzP7Gg/lhJPUb7nO0I+11lwDhebGocUTOtlHw==
+  dependencies:
+    tslib "2.2.0"
+
+"@tsed/platform-views@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/platform-views/-/platform-views-6.75.4.tgz#c88a16b5bdf4c714220e3dfaf10c914a58433343"
+  integrity sha512-tktHl6Jj7+z6UR6ycLPf0sadHVPeDWHt93NRrT+SXKHhVCcBLEiQckl1ddq3Wi7RPhgLIpKnAqRw+mANUYZF6A==
+  dependencies:
+    consolidate "^0.16.0"
+    ejs "^3.1.5"
+    tslib "2.2.0"
+
+"@tsed/schema@6.75.4":
+  version "6.75.4"
+  resolved "https://registry.yarnpkg.com/@tsed/schema/-/schema-6.75.4.tgz#0aae81e4f8b307926a7118e69c81721636724118"
+  integrity sha512-JcT8XEqLJykU807zx4K7yUcQMYnAvtccTsZBdxxdRG7lgdd9DEL1vZda/sfpsNOrkTuSzgQBSzRkvMCqPefSig==
+  dependencies:
+    "@tsed/core" "6.75.4"
+    "@tsed/openspec" "6.75.4"
+    change-case "4.1.2"
     micromatch "4.0.2"
-    tslib "2.0.1"
+    tslib "2.2.0"
 
 "@types/body-parser@*":
   version "1.19.1"
@@ -189,6 +305,11 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
+
+"@types/cache-manager@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@types/cache-manager/-/cache-manager-3.4.2.tgz#d57e7e5e6374d1037bdce753a05c9703e4483401"
+  integrity sha512-1IwA74t5ID4KWo0Kndal16MhiPSZgMe1fGc+MLT6j5r+Ab7jku36PFTl4PP6MiWw0BJscM9QpZEo00qixNQoRg==
 
 "@types/connect@*":
   version "3.4.35"
@@ -206,27 +327,34 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@4.17.11":
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
-  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
+"@types/express@4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/indy-sdk@^1.16.5":
-  version "1.16.5"
-  resolved "https://registry.yarnpkg.com/@types/indy-sdk/-/indy-sdk-1.16.5.tgz#e9b6b917f8a95b5782d9eb7bc8be713c0f971b21"
-  integrity sha512-eDY2RIUdHIhVytx1k9u2mQgXfw1Fs3sW05kP8h3TDXl8mVXsxQyGs336z2GIApUux8vftsQOVEhrX13OinUmwQ==
+"@types/indy-sdk@^1.16.6":
+  version "1.16.6"
+  resolved "https://registry.yarnpkg.com/@types/indy-sdk/-/indy-sdk-1.16.6.tgz#ec8df3dd70cb939c85caa6ebcc32d851e2f3c454"
+  integrity sha512-BhmqsM2z65aOrg6Hum7YICX02dQA2OS05BjEypdoScmPO3ySsZ5QXngeh6pAi+se5yGYp+cL5msoTqldAhlOGA==
   dependencies:
     buffer "^6.0.0"
 
-"@types/json-schema@7.0.6":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
-  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+"@types/indy-sdk@^1.16.7":
+  version "1.16.7"
+  resolved "https://registry.yarnpkg.com/@types/indy-sdk/-/indy-sdk-1.16.7.tgz#ee8a14e0ef690d675fd173e2cae8abe933856fb7"
+  integrity sha512-jPAcVgjM3jmrLhUVeCqca6Uw1kWcGAdEWI/n7eiU5OfMNSjvweb13jA+1a3ZfioXB0ZPvBxkQRbDHL93fxT8YA==
+  dependencies:
+    buffer "^6.0.0"
+
+"@types/json-schema@7.0.7":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
 "@types/mime@^1":
   version "1.3.2"
@@ -238,10 +366,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node-fetch@^2.5.7":
-  version "2.5.11"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.11.tgz#ce22a2e65fc8999f4dbdb7ddbbcf187d755169e4"
-  integrity sha512-2upCKaqVZETDRb8A2VTaRymqFBEgH8u6yr96b/u3+1uQEPDRo3mJLEiPk7vdXBHRtjwkjqzFYMJXrt0Z9QsYjQ==
+"@types/node-fetch@^2.5.10":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -279,6 +407,13 @@
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.6.3.tgz#31ca2e997bf13a0fffca30a25747d5b9f7dbb7de"
   integrity sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw==
 
+"@types/ws@^7.4.4":
+  version "7.4.7"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+  dependencies:
+    "@types/node" "*"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -298,6 +433,16 @@ accepts@~1.3.7:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
+  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -350,6 +495,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -357,7 +507,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -409,6 +559,11 @@ async@0.9.x:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
+async@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 async@^2.6.2:
   version "2.6.3"
@@ -488,19 +643,19 @@ borc@^3.0.0:
     json-text-sequence "~0.3.0"
     readable-stream "^3.6.0"
 
-boxen@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
-  integrity sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==
+boxen@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
+  integrity sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==
   dependencies:
     ansi-align "^3.0.0"
-    camelcase "^5.3.1"
-    chalk "^3.0.0"
-    cli-boxes "^2.2.0"
-    string-width "^4.1.0"
-    term-size "^2.1.0"
-    type-fest "^0.8.1"
+    camelcase "^6.2.0"
+    chalk "^4.1.0"
+    cli-boxes "^2.2.1"
+    string-width "^4.2.2"
+    type-fest "^0.20.2"
     widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -566,6 +721,15 @@ cacache@^15.0.5:
     tar "^6.0.2"
     unique-filename "^1.1.1"
 
+cache-manager@^3.4.1:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-3.4.4.tgz#c69814763d3f3031395ae0d3a9a9296a91602226"
+  integrity sha512-oayy7ukJqNlRUYNUfQBwGOLilL0X5q7GpuaF19Yqwo6qdx49OoTZKRIF5qbbr+Ru8mlTvOpvnMvVq6vw72pOPg==
+  dependencies:
+    async "3.2.0"
+    lodash "^4.17.21"
+    lru-cache "6.0.0"
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -579,7 +743,7 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-camel-case@^4.1.1:
+camel-case@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
   integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
@@ -587,12 +751,12 @@ camel-case@^4.1.1:
     pascal-case "^3.1.2"
     tslib "^2.0.3"
 
-camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+camelcase@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-capital-case@^1.0.3, capital-case@^1.0.4:
+capital-case@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
   integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
@@ -618,31 +782,31 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-change-case@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.1.tgz#d5005709275952e7963fed7b91e4f9fdb6180afa"
-  integrity sha512-qRlUWn/hXnX1R1LBDF/RelJLiqNjKjUqlmuBVSEIyye8kq49CXqkZWKmi8XeUAdDXWFOcGLUMZ+aHn3Q5lzUXw==
+change-case@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
   dependencies:
-    camel-case "^4.1.1"
-    capital-case "^1.0.3"
-    constant-case "^3.0.3"
-    dot-case "^3.0.3"
-    header-case "^2.0.3"
-    no-case "^3.0.3"
-    param-case "^3.0.3"
-    pascal-case "^3.1.1"
-    path-case "^3.0.3"
-    sentence-case "^3.0.3"
-    snake-case "^3.0.3"
-    tslib "^1.10.0"
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 chokidar@^3.2.2:
   version "3.5.2"
@@ -688,7 +852,7 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-cli-boxes@^2.2.0:
+cli-boxes@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
@@ -785,7 +949,7 @@ consolidate@^0.16.0:
   dependencies:
     bluebird "^3.7.2"
 
-constant-case@^3.0.3:
+constant-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
   integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
@@ -878,6 +1042,11 @@ debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
@@ -935,7 +1104,7 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dot-case@^3.0.3, dot-case@^3.0.4:
+dot-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
   integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
@@ -1104,6 +1273,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -1209,17 +1383,17 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-dirs@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.1.0.tgz#e9046a49c806ff04d6c1825e196c8f0091e8df4d"
-  integrity sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==
+global-dirs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
+  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
   dependencies:
-    ini "1.3.7"
+    ini "2.0.0"
 
-globby@11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
-  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+globby@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -1270,7 +1444,7 @@ has-yarn@^2.1.0:
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
   integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
 
-header-case@^2.0.3:
+header-case@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
   integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
@@ -1373,10 +1547,10 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-indy-sdk@^1.16.0-dev-1634:
-  version "1.16.0-dev-1634"
-  resolved "https://registry.yarnpkg.com/indy-sdk/-/indy-sdk-1.16.0-dev-1634.tgz#4ddda17f9f86bc7bd56be1b5190e75523227cb5c"
-  integrity sha512-sYhkS9S9rNnfUBQe2WvI3eQKpOwjb0HdBOIeycT41aKHfZPGaAHoyJvxgy9QmcgHjqCxDOTsC5H9g4vbq3uSvA==
+indy-sdk@^1.16.0-dev-1636:
+  version "1.16.0-dev-1636"
+  resolved "https://registry.yarnpkg.com/indy-sdk/-/indy-sdk-1.16.0-dev-1636.tgz#e53b719a6ce536459b356dbf32b9a7cb18ca59e8"
+  integrity sha512-1SYJWdf0xCr+Yd7zTLzYxS7i/j/H2dmBj9C5muPPSdh5XPkL133L0QxZ0NmVdciUY4J5TAyyCjdDgvji1ZSwAw==
   dependencies:
     bindings "^1.3.1"
     nan "^2.11.1"
@@ -1405,10 +1579,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
-  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 ini@~1.3.0:
   version "1.3.8"
@@ -1468,23 +1642,23 @@ is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-installed-globally@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
-  integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
   dependencies:
-    global-dirs "^2.0.1"
-    is-path-inside "^3.0.1"
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
 
 is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
-is-npm@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
-  integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
+is-npm@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
+  integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -1496,7 +1670,7 @@ is-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
-is-path-inside@^3.0.1:
+is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -1577,7 +1751,7 @@ keyv@^3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
-latest-version@^5.0.0:
+latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
@@ -1611,12 +1785,22 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^6.0.0:
+lru-cache@6.0.0, lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.4.1.tgz#f7b4046283c79fb7370c36f8fca6aee4324b0a98"
+  integrity sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==
+
+luxon@^1.27.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"
+  integrity sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -1679,7 +1863,7 @@ micromatch@4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
-micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -1847,7 +2031,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-no-case@^3.0.3, no-case@^3.0.4:
+no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
   integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
@@ -1855,10 +2039,17 @@ no-case@^3.0.3, no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@^8.0.0:
   version "8.1.0"
@@ -1876,10 +2067,10 @@ node-gyp@^8.0.0:
     tar "^6.1.0"
     which "^2.0.2"
 
-nodemon@2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.7.tgz#6f030a0a0ebe3ea1ba2a38f71bf9bab4841ced32"
-  integrity sha512-XHzK69Awgnec9UzHr1kc8EomQh4sjTQ8oRf8TsGrSmHDx9/UmiGG9E/mM3BuTfNeFwdNBvrqQq/RHL0xIeyFOA==
+nodemon@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.14.tgz#287c7a2f6cd8a18b07e94cd776ecb6a82e4ba439"
+  integrity sha512-frcpDx+PviKEQRSYzwhckuO2zoHcBYLHI754RE9z5h1RGtrngerc04mLpQQCPWBkH/2ObrX7We9YiwVSYZpFJQ==
   dependencies:
     chokidar "^3.2.2"
     debug "^3.2.6"
@@ -1890,7 +2081,7 @@ nodemon@2.0.7:
     supports-color "^5.5.0"
     touch "^3.1.0"
     undefsafe "^2.0.3"
-    update-notifier "^4.1.0"
+    update-notifier "^5.1.0"
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -1977,7 +2168,7 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-param-case@^3.0.3:
+param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
   integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
@@ -1990,7 +2181,7 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-pascal-case@^3.1.1, pascal-case@^3.1.2:
+pascal-case@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
   integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
@@ -1998,7 +2189,7 @@ pascal-case@^3.1.1, pascal-case@^3.1.2:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-path-case@^3.0.3:
+path-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
   integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
@@ -2075,7 +2266,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-pupa@^2.0.1:
+pupa@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
@@ -2086,6 +2277,16 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+query-string@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2213,6 +2414,13 @@ rxjs@^7.1.0:
   dependencies:
     tslib "~2.1.0"
 
+rxjs@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
+  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+  dependencies:
+    tslib "~2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -2245,7 +2453,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2, semver@^7.3.5:
+semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -2271,7 +2479,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-sentence-case@^3.0.3:
+sentence-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
   integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
@@ -2327,7 +2535,7 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snake-case@^3.0.3:
+snake-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
   integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
@@ -2352,7 +2560,7 @@ socks@^2.3.3:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-source-map-support@0.5.19, source-map-support@^0.5.17:
+source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -2364,6 +2572,11 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
 
 ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"
@@ -2392,6 +2605,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -2427,6 +2645,15 @@ string-width@^4.0.0, string-width@^4.1.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -2475,6 +2702,13 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -2506,11 +2740,6 @@ tar@^6.0.2, tar@^6.1.0:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-term-size@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
-  integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
-
 to-readable-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
@@ -2535,37 +2764,55 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-ts-node@9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+ts-node@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.3.0.tgz#a797f2ed3ff50c9a5d814ce400437cb0c1c048b4"
+  integrity sha512-RYIy3i8IgpFH45AX4fQHExrT8BxDeKTdC83QFJkNzkvt8uFB6QJ8XMyhynYiKMLxt9a7yuXaDBZNOYS3XjDcYw==
   dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
 
-tslib@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
-  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+tslib@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
-tslib@2.1.0, tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+tslib@2.3.0, tslib@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@^1.10.0, tslib@^1.9.3:
+tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslog@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/tslog/-/tslog-3.2.1.tgz#37df1301211901eb65fd61b9ad7c8554264a7699"
+  integrity sha512-m8wAtox9wt+h6UDcN1WAQnYwRDOGhMIOp+GAuuufo8T8qKuu726i2W3r47BrA69goVOwgUkp5YwDTvAxTktvPg==
+  dependencies:
+    source-map-support "^0.5.19"
 
 tsyringe@^4.5.0:
   version "4.6.0"
@@ -2574,10 +2821,10 @@ tsyringe@^4.5.0:
   dependencies:
     tslib "^1.9.3"
 
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-is@^1.6.4, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -2599,10 +2846,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+typescript@~4.3.0:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uint8arrays@^2.1.3:
   version "2.1.5"
@@ -2649,22 +2896,23 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-update-notifier@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.3.tgz#be86ee13e8ce48fb50043ff72057b5bd598e1ea3"
-  integrity sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==
+update-notifier@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
+  integrity sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==
   dependencies:
-    boxen "^4.2.0"
-    chalk "^3.0.0"
+    boxen "^5.0.0"
+    chalk "^4.1.0"
     configstore "^5.0.1"
     has-yarn "^2.1.0"
     import-lazy "^2.1.0"
     is-ci "^2.0.0"
-    is-installed-globally "^0.3.1"
-    is-npm "^4.0.0"
+    is-installed-globally "^0.4.0"
+    is-npm "^5.0.0"
     is-yarn-global "^0.3.0"
-    latest-version "^5.0.0"
-    pupa "^2.0.1"
+    latest-version "^5.1.0"
+    pupa "^2.1.1"
+    semver "^7.3.4"
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
 
@@ -2719,6 +2967,19 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -2739,6 +3000,15 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

- Updates AFJ to latest version (and also uses `latest` as version indicator). This means if a new version is released it should be picked up by the CI. This also means the AFJ backchannel will probably break more often, as we're still making a lot of breaking changes. I hope this will make sure I keep it up to date :)
- Removes the `setTimeouts` from the controller and instead uses events to know when we can take the next action (@nodlesh)
- @lauravuo-techlab it seems that updating AFJ fixed the issue with findy (yay! :)). On my local machine the following command (`./manage run -d javascript -b findy -t @AcceptanceTest -t @AIP10 -t ~@wip -t ~@revocation`) all tests succeeds


